### PR TITLE
fix: don't fail when non-version labels are added to PR

### DIFF
--- a/.github/workflows/create-tag-and-release.yaml
+++ b/.github/workflows/create-tag-and-release.yaml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - name: Validate PR labels
         id: validate_labels
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -26,8 +26,7 @@ jobs:
 
             const labels = response.data.map(label => label.name.toLowerCase());
             
-            // Support both old format (patch, minor, major) and new format (patch change, minor change, major change)
-            const versionLabels = ['patch', 'minor', 'major', 'patch change', 'minor change', 'major change'];
+            const versionLabels = ['patch', 'minor', 'major'];
             const foundVersionLabels = labels.filter(label => versionLabels.includes(label));
 
             if (foundVersionLabels.length === 0) {
@@ -38,13 +37,11 @@ jobs:
             }
 
             if (foundVersionLabels.length > 1) {
-              core.setFailed('PR must have exactly one version label (patch/minor/major or patch change/minor change/major change)');
+              core.setFailed('PR must have exactly one version label (patch/minor/major)');
               return;
             }
 
-            // Normalize the label to remove "change" suffix
-            const normalizedType = foundVersionLabels[0].replace(' change', '').trim();
-            core.setOutput('version_type', normalizedType);
+            core.setOutput('version_type', foundVersionLabels[0]);
 
   create-tag:
     name: Create Tag
@@ -59,7 +56,7 @@ jobs:
       version_type: ${{ steps.get_version.outputs.version_type }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -120,7 +117,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/semver-label-check.yaml
+++ b/.github/workflows/semver-label-check.yaml
@@ -39,7 +39,7 @@ jobs:
               issue_number: context.issue.number
             });
 
-            const versionLabels = ['patch change', 'minor change', 'major change'];
+            const versionLabels = ['patch', 'minor', 'major'];
             const foundVersionLabels = response.data
               .map(label => label.name.toLowerCase())
               .filter(name => versionLabels.includes(name));
@@ -62,11 +62,11 @@ jobs:
             // Calculate next version based on label
             function getNextVersion(label) {
               switch(label) {
-                case 'major change':
+                case 'major':
                   return `${major + 1}.0.0`;
-                case 'minor change':
+                case 'minor':
                   return `${major}.${minor + 1}.0`;
-                case 'patch change':
+                case 'patch':
                   return `${major}.${minor}.${patch + 1}`;
                 default:
                   return currentVersion;
@@ -79,10 +79,11 @@ jobs:
 
             if (foundVersionLabels.length === 0) {
               status += '⏳ **Waiting:** No version label found yet.\n\n' +
-                       'Please add one of the following labels before merging:\n' +
-                       '- `patch change`: backwards-compatible bug fixes\n' +
-                       '- `minor change`: backwards-compatible features\n' +
-                       '- `major change`: breaking changes';
+                       'This PR will default to a **patch** bump when merged.\n' +
+                       'To specify a different version bump, add one of these labels:\n' +
+                       '- `patch`: backwards-compatible bug fixes\n' +
+                       '- `minor`: backwards-compatible features\n' +
+                       '- `major`: breaking changes';
             } else if (foundVersionLabels.length > 1) {
               status += '❌ **Error:** Multiple version labels detected!\n\n' +
                        `Found labels: ${foundVersionLabels.map(l => `\`${l}\``).join(', ')}\n\n` +
@@ -98,13 +99,13 @@ jobs:
                        `\`v${currentVersion}\` → \`v${nextVersion}\`\n\n`;
 
               switch(labelType) {
-                case 'major change':
+                case 'major':
                   status += '- **Major** version increment (breaking changes)';
                   break;
-                case 'minor change':
+                case 'minor':
                   status += '- **Minor** version increment (new features, backwards compatible)';
                   break;
-                case 'patch change':
+                case 'patch':
                   status += '- **Patch** version increment (bug fixes, backwards compatible)';
                   break;
               }

--- a/.github/workflows/semver-label-check.yaml
+++ b/.github/workflows/semver-label-check.yaml
@@ -78,13 +78,11 @@ jobs:
             let shouldFail = false;
 
             if (foundVersionLabels.length === 0) {
-              status += '❌ **Error:** No version label found!\n\n' +
-                       'This PR requires exactly one of the following labels:\n' +
+              status += '⏳ **Waiting:** No version label found yet.\n\n' +
+                       'Please add one of the following labels before merging:\n' +
                        '- `patch change`: backwards-compatible bug fixes\n' +
                        '- `minor change`: backwards-compatible features\n' +
-                       '- `major change`: breaking changes\n\n' +
-                       'Please add one label to specify the type of version change.';
-              shouldFail = true;
+                       '- `major change`: breaking changes';
             } else if (foundVersionLabels.length > 1) {
               status += '❌ **Error:** Multiple version labels detected!\n\n' +
                        `Found labels: ${foundVersionLabels.map(l => `\`${l}\``).join(', ')}\n\n` +

--- a/docs/semver-label-check.md
+++ b/docs/semver-label-check.md
@@ -52,9 +52,9 @@ Pull requests must be labeled with the type of change according to [semver.org](
 
 | Label | Version Change | Use For |
 |-------|----------------|---------|
-| `patch change` | `v1.2.3` → `v1.2.4` | Bug fixes, small improvements, documentation |
-| `minor change` | `v1.2.3` → `v1.3.0` | New features that don't break existing functionality |
-| `major change` | `v1.2.3` → `v2.0.0` | Breaking changes, removed features, API changes |
+| `patch` | `v1.2.3` → `v1.2.4` | Bug fixes, small improvements, documentation |
+| `minor` | `v1.2.3` → `v1.3.0` | New features that don't break existing functionality |
+| `major` | `v1.2.3` → `v2.0.0` | Breaking changes, removed features, API changes |
 
 ### Workflow Behavior
 
@@ -70,10 +70,11 @@ The workflow runs, passes, and posts a reminder comment:
 ### Version Label Status
 ⏳ **Waiting:** No version label found yet.
 
-Please add one of the following labels before merging:
-- `patch change`: backwards-compatible bug fixes
-- `minor change`: backwards-compatible features
-- `major change`: breaking changes
+This PR will default to a **patch** bump when merged.
+To specify a different version bump, add one of these labels:
+- `patch`: backwards-compatible bug fixes
+- `minor`: backwards-compatible features
+- `major`: breaking changes
 ```
 
 **When a valid label is added:**
@@ -239,13 +240,13 @@ on:
 
 **Status check stuck on pending?**
 
-This is expected behavior. The check stays pending until a label is added to the PR. Add a semver label (`patch change`, `minor change`, or `major change`) to trigger the workflow.
+This is expected behavior. The check stays pending until a label is added to the PR. Add a semver label (`patch`, `minor`, or `major`) to trigger the workflow.
 
 **Labels not found?**
 
 Ensure you've created the required labels in your repository:
 - Go to Settings → Labels
-- Create `patch change`, `minor change`, and `major change` labels
+- Create `patch`, `minor`, and `major` labels
 - Color doesn't matter, but use distinct colors for easy identification
 
 **Status check not blocking merge?**

--- a/docs/semver-label-check.md
+++ b/docs/semver-label-check.md
@@ -64,18 +64,16 @@ The status check stays **pending** and does not run. No failure email is sent.
 
 **When a non-version label is added (or a version label is removed):**
 
-The workflow runs and fails with a comment:
+The workflow runs, passes, and posts a reminder comment:
 
 ```
 ### Version Label Status
-❌ **Error:** No version label found!
+⏳ **Waiting:** No version label found yet.
 
-This PR requires exactly one of the following labels:
+Please add one of the following labels before merging:
 - `patch change`: backwards-compatible bug fixes
 - `minor change`: backwards-compatible features
 - `major change`: breaking changes
-
-Please add one label to specify the type of version change.
 ```
 
 **When a valid label is added:**


### PR DESCRIPTION
## Summary

- When a non-version label (e.g. `bug`, `enhancement`) is added to a PR, the semver check now **passes** with a reminder comment instead of failing
- Only fails when multiple version labels are present (actual conflict)
- Prevents failure notification emails when adding any label that isn't a version label